### PR TITLE
Add external writing links to blog page

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -71,17 +71,49 @@
                 <p class="text-xl text-forest-600 max-w-3xl mx-auto">Thoughts on technology, writing, and the intersection of both.</p>
             </div>
 
-            <div class="max-w-4xl mx-auto">
-                <div class="bg-gradient-to-r from-pink-50 to-forest-50 rounded-xl p-12 text-center border border-pink-200 shadow-lg">
-                    <div class="mb-6">
-                        <div class="inline-flex items-center justify-center w-16 h-16 bg-pink-100 rounded-full mb-4">
-                            <svg class="w-8 h-8 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="max-w-4xl mx-auto space-y-8">
+                <div class="grid md:grid-cols-2 gap-6">
+                    <div class="bg-white rounded-xl p-6 shadow-lg border-l-4 border-pink-500">
+                        <div class="flex items-center mb-4">
+                            <div class="w-12 h-12 bg-pink-100 rounded-full flex items-center justify-center mr-4">
+                                <svg class="w-6 h-6 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H14"></path>
+                                </svg>
+                            </div>
+                            <h3 class="text-xl font-bold text-forest-800">The Duke Chronicle</h3>
+                        </div>
+                        <p class="text-forest-600 mb-4">Read my articles and contributions to Duke University's independent student newspaper, covering campus life, culture, and student perspectives.</p>
+                        <a href="https://www.dukechronicle.com/by/heidi-smith" target="_blank" class="inline-block bg-pink-600 hover:bg-pink-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">
+                            View Articles
+                        </a>
+                    </div>
+
+                    <div class="bg-white rounded-xl p-6 shadow-lg border-l-4 border-forest-500">
+                        <div class="flex items-center mb-4">
+                            <div class="w-12 h-12 bg-forest-100 rounded-full flex items-center justify-center mr-4">
+                                <svg class="w-6 h-6 text-forest-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3l14 9-14 9V3z"></path>
+                                </svg>
+                            </div>
+                            <h3 class="text-xl font-bold text-forest-800">The Trek</h3>
+                        </div>
+                        <p class="text-forest-600 mb-4">Explore my outdoor adventure writing and hiking stories published on The Trek, sharing experiences from trails and wilderness adventures.</p>
+                        <a href="https://thetrek.co/author/heidi-smith/" target="_blank" class="inline-block bg-forest-700 hover:bg-forest-800 text-white font-semibold py-2 px-6 rounded-lg transition-colors">
+                            Read Stories
+                        </a>
+                    </div>
+                </div>
+
+                <div class="bg-gradient-to-r from-pink-50 to-forest-50 rounded-xl p-8 text-center border border-pink-200">
+                    <div class="mb-4">
+                        <div class="inline-flex items-center justify-center w-14 h-14 bg-pink-100 rounded-full mb-3">
+                            <svg class="w-7 h-7 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path>
                             </svg>
                         </div>
                     </div>
-                    <h3 class="text-2xl font-bold text-forest-800 mb-4">Coming Soon</h3>
-                    <p class="text-forest-600 text-lg font-medium">Blog posts about technology, literature, and digital humanities are coming soon!</p>
+                    <h3 class="text-xl font-bold text-forest-800 mb-3">Personal Blog Coming Soon</h3>
+                    <p class="text-forest-600 font-medium">New posts about technology, literature, and digital humanities will be published here!</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Added links to Duke Chronicle articles at dukechronicle.com/by/heidi-smith
- Added links to The Trek outdoor writing at thetrek.co/author/heidi-smith/
- Created attractive card layout showcasing published work
- Maintained personal blog coming soon section

🤖 Generated with [Claude Code](https://claude.ai/code)